### PR TITLE
Performance Improvement through the Use of steady_clock and Saving a Local Copy of the Global Node List

### DIFF
--- a/src/mtp/model/logical-process.cc
+++ b/src/mtp/model/logical-process.cc
@@ -182,7 +182,7 @@ LogicalProcess::ProcessOneRound()
     Time grantedTime =
         Min(MtpInterface::GetSmallestTime() + m_lookAhead, MtpInterface::GetNextPublicTime());
 
-    auto start = std::chrono::system_clock::now();
+    auto start = std::chrono::steady_clock::now();
 
     // process events
     while (Next() <= grantedTime)
@@ -199,7 +199,7 @@ LogicalProcess::ProcessOneRound()
         next.impl->Unref();
     }
 
-    auto end = std::chrono::system_clock::now();
+    auto end = std::chrono::steady_clock::now();
     m_executionTime = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
 }
 

--- a/src/mtp/model/multithreaded-simulator-impl.cc
+++ b/src/mtp/model/multithreaded-simulator-impl.cc
@@ -138,12 +138,10 @@ MultithreadedSimulatorImpl::ScheduleWithContext(uint32_t context,
                                                 EventImpl* event)
 {
     NS_LOG_FUNCTION(this << context << delay.GetTimeStep() << event);
-    if (m_savedNodeList.GetN() <= context)
-    {
-        m_savedNodeList = NodeContainer::GetGlobal();
-    }
-    LogicalProcess* remote = MtpInterface::GetSystem(m_savedNodeList.Get(context)->GetSystemId());
-    MtpInterface::GetSystem()->ScheduleWithContext(remote, context, delay, event);
+    const bool useSaved = (context < m_savedNodeList.GetN());
+    Ptr<Node> node = useSaved ? m_savedNodeList.Get(context) : NodeList::GetNode(context);
+    LogicalProcess* remote = MtpInterface::GetSystem(node->GetSystemId());
+    remote->ScheduleWithContext(remote, context, delay, event);
 }
 
 EventId
@@ -303,6 +301,7 @@ MultithreadedSimulatorImpl::Partition()
     NS_LOG_FUNCTION(this);
     uint32_t systemId = 0;
     const NodeContainer nodes = NodeContainer::GetGlobal();
+    m_savedNodeList = NodeContainer::GetGlobal();
     bool* visited = new bool[nodes.GetN()]{false};
     std::queue<Ptr<Node>> q;
 

--- a/src/mtp/model/multithreaded-simulator-impl.cc
+++ b/src/mtp/model/multithreaded-simulator-impl.cc
@@ -138,10 +138,16 @@ MultithreadedSimulatorImpl::ScheduleWithContext(uint32_t context,
                                                 EventImpl* event)
 {
     NS_LOG_FUNCTION(this << context << delay.GetTimeStep() << event);
-    const bool useSaved = (context < m_savedNodeList.GetN());
-    Ptr<Node> node = useSaved ? m_savedNodeList.Get(context) : NodeList::GetNode(context);
-    LogicalProcess* remote = MtpInterface::GetSystem(node->GetSystemId());
-    remote->ScheduleWithContext(remote, context, delay, event);
+    LogicalProcess* remote = nullptr;
+    if (m_savedNodeList.GetN() > context)
+    {
+        remote = MtpInterface::GetSystem(m_savedNodeList.Get(context)->GetSystemId());
+    }
+    else
+    {
+        remote = MtpInterface::GetSystem(NodeList::GetNode(context)->GetSystemId());
+    }
+    MtpInterface::GetSystem()->ScheduleWithContext(remote, context, delay, event);
 }
 
 EventId
@@ -301,7 +307,7 @@ MultithreadedSimulatorImpl::Partition()
     NS_LOG_FUNCTION(this);
     uint32_t systemId = 0;
     const NodeContainer nodes = NodeContainer::GetGlobal();
-    m_savedNodeList = NodeContainer::GetGlobal();
+    m_savedNodeList = nodes;
     bool* visited = new bool[nodes.GetN()]{false};
     std::queue<Ptr<Node>> q;
 

--- a/src/mtp/model/multithreaded-simulator-impl.cc
+++ b/src/mtp/model/multithreaded-simulator-impl.cc
@@ -138,7 +138,11 @@ MultithreadedSimulatorImpl::ScheduleWithContext(uint32_t context,
                                                 EventImpl* event)
 {
     NS_LOG_FUNCTION(this << context << delay.GetTimeStep() << event);
-    LogicalProcess* remote = MtpInterface::GetSystem(NodeList::GetNode(context)->GetSystemId());
+    if (m_savedNodeList.GetN() <= context)
+    {
+        m_savedNodeList = NodeContainer::GetGlobal();
+    }
+    LogicalProcess* remote = MtpInterface::GetSystem(m_savedNodeList.Get(context)->GetSystemId());
     MtpInterface::GetSystem()->ScheduleWithContext(remote, context, delay, event);
 }
 

--- a/src/mtp/model/multithreaded-simulator-impl.h
+++ b/src/mtp/model/multithreaded-simulator-impl.h
@@ -31,6 +31,7 @@
 #include "ns3/nstime.h"
 #include "ns3/object-factory.h"
 #include "ns3/simulator-impl.h"
+#include "ns3/node-container.h"
 
 #include <list>
 
@@ -94,6 +95,7 @@ class MultithreadedSimulatorImpl : public SimulatorImpl
     Time m_minLookahead;
     TypeId m_schedulerTypeId;
     std::list<EventId> m_destroyEvents;
+    NodeContainer m_savedNodeList;
 };
 
 } // namespace ns3


### PR DESCRIPTION
When using unison-for-ns-3, I identified two aspects that can be optimized.
1. When calculating the interval (m_executionTime) of one round, using the steady_clock can reduce the time cost. In my own use case, I observed a 5% reduction in time.
1. In my use case, I frequently called the ScheduleWithContext function and found that the NodeList::GetNode() function consumed a significant amount of time during the simulation. Therefore, I created a m_savedNodeList to store the global NodeList and avoid calling the NodeList::GetNode() function. In my simulation scenario, when the ScheduleWithContext function is called frequently, this optimization saves approximately 15% of the time.